### PR TITLE
Make tokens pallet instantiable

### DIFF
--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -155,6 +155,7 @@ pub mod module {
 		fn transfer_all() -> Weight;
 	}
 
+	// TODO: Make instantiable
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;


### PR DESCRIPTION
For tackling https://github.com/open-web3-stack/open-runtime-module-library/issues/391 and have different instances of the tokens pallet that could act as separate "bags of tokens" used for different purposes like representing fiat assets on one bag and USDv collaterals with a different one. 