### PR TITLE
[feat] make fee handler generic

### DIFF
--- a/payments/src/tests.rs
+++ b/payments/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use frame_support::{assert_noop, assert_ok, storage::with_transaction};
 use orml_traits::{MultiCurrency, MultiReservableCurrency, NamedMultiReservableCurrency};
-use sp_runtime::{Percent, TransactionOutcome};
+use sp_runtime::{traits::Zero, Percent, TransactionOutcome};
 
 type Error = crate::Error<Test>;
 
@@ -54,7 +54,7 @@ fn test_pay_works() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::Created,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+				fee_amount: Zero::zero(),
 			})
 		);
 		// the payment amount should be reserved correctly
@@ -102,7 +102,7 @@ fn test_pay_works() {
 				incentive_amount: 2,
 				state: PaymentState::Created,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+				fee_amount: Zero::zero(),
 			})
 		);
 
@@ -134,7 +134,7 @@ fn test_cancel_works() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::Created,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+				fee_amount: Zero::zero(),
 			})
 		);
 		// the payment amount should be reserved
@@ -205,7 +205,7 @@ fn test_release_works() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::Created,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+				fee_amount: Zero::zero(),
 			})
 		);
 		// the payment amount should be reserved
@@ -367,7 +367,7 @@ fn test_charging_fee_payment_works() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::Created,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, expected_fee_amount)),
+				fee_amount: expected_fee_amount
 			})
 		);
 		// the payment amount should be reserved
@@ -426,7 +426,7 @@ fn test_charging_fee_payment_works_when_canceled() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::Created,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, expected_fee_amount)),
+				fee_amount: expected_fee_amount,
 			})
 		);
 		// the payment amount should be reserved
@@ -475,7 +475,7 @@ fn test_pay_with_remark_works() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::Created,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+				fee_amount: Zero::zero(),
 			})
 		);
 		// the payment amount should be reserved correctly
@@ -553,7 +553,7 @@ fn test_do_not_overwrite_logic_works() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::NeedsReview,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+				fee_amount: Zero::zero(),
 			},
 		);
 
@@ -613,7 +613,7 @@ fn test_request_refund() {
 					cancel_block: expected_cancel_block
 				},
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+				fee_amount: Zero::zero(),
 			})
 		);
 
@@ -678,7 +678,7 @@ fn test_dispute_refund() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::NeedsReview,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+				fee_amount: Zero::zero(),
 			})
 		);
 
@@ -723,7 +723,7 @@ fn test_request_payment() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::PaymentRequested,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+				fee_amount: Zero::zero(),
 			})
 		);
 
@@ -799,7 +799,7 @@ fn test_accept_and_pay() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::PaymentRequested,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+				fee_amount: Zero::zero(),
 			})
 		);
 
@@ -870,7 +870,7 @@ fn test_accept_and_pay_should_charge_fee_correctly() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::PaymentRequested,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, expected_fee_amount)),
+				fee_amount: expected_fee_amount
 			})
 		);
 
@@ -947,7 +947,7 @@ fn test_create_payment_works() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::Created,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, expected_fee_amount)),
+				fee_amount: expected_fee_amount
 			})
 		);
 
@@ -975,7 +975,7 @@ fn test_create_payment_works() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::Created,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, expected_fee_amount)),
+				fee_amount: expected_fee_amount
 			})
 		);
 	});
@@ -1015,7 +1015,7 @@ fn test_reserve_payment_amount_works() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::Created,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, expected_fee_amount)),
+				fee_amount: expected_fee_amount
 			})
 		);
 
@@ -1065,7 +1065,7 @@ fn test_reserve_payment_amount_works() {
 				incentive_amount: expected_incentive_amount,
 				state: PaymentState::Created,
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, expected_fee_amount)),
+				fee_amount: expected_fee_amount
 			})
 		);
 	});
@@ -1302,7 +1302,7 @@ fn test_automatic_refund_works() {
 					cancel_block: CANCEL_BLOCK
 				},
 				resolver_account: RESOLVER_ACCOUNT,
-				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+				fee_amount: Zero::zero(),
 			})
 		);
 

--- a/payments/src/types.rs
+++ b/payments/src/types.rs
@@ -27,8 +27,8 @@ pub struct PaymentDetail<T: pallet::Config> {
 	pub state: PaymentState<T>,
 	/// account that can settle any disputes created in the payment
 	pub resolver_account: T::AccountId,
-	/// fee charged and recipient account details
-	pub fee_detail: Option<(T::AccountId, BalanceOf<T>)>,
+	/// fee charged details
+	pub fee_amount: BalanceOf<T>,
 }
 
 /// The `PaymentState` enum tracks the possible states that a payment can be in.
@@ -95,13 +95,16 @@ pub trait DisputeResolver<Account> {
 /// Fee Handler trait that defines how to handle marketplace fees to every
 /// payment/swap
 pub trait FeeHandler<T: pallet::Config> {
-	/// Get the distribution of fees to marketplace participants
-	fn apply_fees(
+	/// Get the amount of fee to charge user
+	fn get_fee_amount(
 		from: &T::AccountId,
 		to: &T::AccountId,
 		detail: &PaymentDetail<T>,
 		remark: Option<&[u8]>,
-	) -> (T::AccountId, Percent);
+	) -> BalanceOf<T>;
+
+	/// Deduct the fee from the user transaction
+	fn apply_fees(from: &T::AccountId, to: &T::AccountId, detail: &PaymentDetail<T>) -> DispatchResult;
 }
 
 /// Types of Tasks that can be scheduled in the pallet


### PR DESCRIPTION
Expands the FeeHandler trait to make it more generic, the trait is now 

```rust
pub trait FeeHandler<T: pallet::Config> {
	/// Get the amount of fee to charge user
	fn get_fee_amount(
		from: &T::AccountId,
		to: &T::AccountId,
		detail: &PaymentDetail<T>,
		remark: Option<&[u8]>,
	) -> BalanceOf<T>;

	/// Deduct the fee from the user transaction
	fn apply_fees(from: &T::AccountId, to: &T::AccountId, detail: &PaymentDetail<T>) -> DispatchResult;
}
```

During the initial creation of the payment, the get_fee_amount is called to store the fee_amount, when the payment is settled, the apply_fees function is called, depending on the implementation it may deduct fee from user and transfer to fee recipients.

The previous logic of transferring to recipients can be achieved by implementing apply_fees like this
```rust
	fn apply_fees(from: &AccountId, _to: &AccountId, detail: &PaymentDetail<Test>) -> DispatchResult {
		// transfer the fee amount to fee recipient account
		<Tokens as MultiCurrency<AccountId>>::transfer(
			detail.asset,
			from,                   // fee is paid by payment creator
			&FEE_RECIPIENT_ACCOUNT, // account of fee recipient
			detail.fee_amount,      // amount of fee
		)
	}
```

Every runtime will have to benchmark the pallet based on their implementation of apply_fees.

Closes #10 since any complex logic can be written in apply_fees.